### PR TITLE
Cast to specific XRM Attribute/Control interfaces for typed methods based in Dataverse attributes type

### DIFF
--- a/src/helpers/typingsHelper.ts
+++ b/src/helpers/typingsHelper.ts
@@ -5,7 +5,7 @@ import { camelize, pascalize, sanitize } from "../utils/ExtensionMethods";
 import { IAttributeDefinition, IOptionValue } from "../utils/Interfaces";
 import { getWorkspaceFolder, writeFileSync } from "../utils/FileSystem";
 import { Placeholders } from "../utils/Placeholders";
-import { AttributeTypeDefinitions, ControlTypeDefinitions , extensionName } from "../utils/Constants";
+import { extensionName } from "../utils/Constants";
 
 const typingNamespace: string = "Xrm";
 const typingInterface: string = "EventContext";
@@ -14,6 +14,53 @@ const typingOmitAttribute = "Omit<FormContext, 'getAttribute'>";
 const typingOmitControl = "Omit<FormContext, 'getControl'>";
 const xrmAttribute = "Attributes.Attribute";
 const xrmControl = "Controls.StandardControl";
+export const AttributeTypeDefinitionMap = new Map<string, string>([
+    ["Boolean","Attributes.BooleanAttribute"],
+    ["Customer","Attributes.LookupAttribute"],
+    ["DateTime","Attributes.DateAttribute"],
+    ["Decimal","Attributes.NumberAttribute"],
+    ["Double","Attributes.NumberAttribute"],
+    ["Integer","Attributes.NumberAttribute"],
+    ["Lookup","Attributes.LookupAttribute"],
+    ["Memo","Attributes.StringAttribute"],
+    ["Money","Attributes.NumberAttribute"],
+    ["Owner","Attributes.LookupAttribute"],
+    ["PartyList","Attributes.LookupAttribute"],
+    ["Picklist", "Attributes.OptionSetAttribute"],
+    ["State","Attributes.OptionSetAttribute"],
+    ["Status","Attributes.OptionSetAttribute"],
+    ["String","Attributes.StringAttribute"],
+    ["Uniqueidentifier","Attributes.StringAttribute"],
+    ["CalendarRules","Attributes.Attribute"],
+    ["Virtual","Attributes.Attribute"],
+    ["BigInt","Attributes.NumberAttribute"],
+    ["ManagedProperty", "Attributes.Attribute"],
+    ["EntityName","Attributes.Attribute"]
+    ]);
+
+const ControlTypeDefinitionMap = new Map<string, string>([
+    ["Boolean","Controls.StandardControl"],
+    ["Customer","Controls.LookupControl"],
+    ["DateTime","Controls.DateControl"],
+    ["Decimal","Controls.NumberControl"],
+    ["Double","Controls.NumberControl"],
+    ["Integer","Controls.NumberControl"],
+    ["Lookup","Controls.LookupControl"],
+    ["Memo","Controls.StringControl"],
+    ["Money","Controls.NumberControl"],
+    ["Owner","Controls.LookupControl"],
+    ["PartyList","Controls.LookupControl"],
+    ["Picklist", "Controls.OptionSetControl"],
+    ["State","Controls.OptionSetControl"],
+    ["Status","Controls.OptionSetControl"],
+    ["String","Controls.StringControl"],
+    ["Uniqueidentifier","Controls.StringControl"],
+    ["CalendarRules","Controls.Control"],
+    ["Virtual","Controls.Control"],
+    ["BigInt","Controls.NumberControl"],
+    ["ManagedProperty", "Controls.Control"],
+    ["EntityName","Controls.Control"]
+    ]);
 export class TypingsHelper {
     /**
      * Initialization constructor for VS Code Context
@@ -83,13 +130,13 @@ export class TypingsHelper {
 
     private createAttributeMethod(attr: IAttributeDefinition): dom.MethodDeclaration {
         return dom.create.method("getAttribute", [dom.create.parameter("name", dom.type.stringLiteral(camelize(attr.LogicalName)))], 
-        dom.create.namedTypeReference(AttributeTypeDefinitions.get(attr.AttributeType)??"Xrm.Control.Attribute"));
+        dom.create.namedTypeReference(AttributeTypeDefinitionMap.get(attr.AttributeType)??"Control.Attribute"));
         //return dom.create.property(camelize(attr.LogicalName), this.convertType(attr.AttributeType.toLowerCase()), dom.DeclarationFlags.Optional);
     }
 
     private createControlMethod(attr: IAttributeDefinition): dom.MethodDeclaration {
         return dom.create.method("getControl", [dom.create.parameter("name", dom.type.stringLiteral(camelize(attr.LogicalName)))],  
-        dom.create.namedTypeReference(ControlTypeDefinitions.get(attr.AttributeType)??"Xrm.Controls.Control"));
+        dom.create.namedTypeReference(ControlTypeDefinitionMap.get(attr.AttributeType)??"Controls.Control"));
         //return dom.create.property(camelize(attr.LogicalName), this.convertType(attr.AttributeType.toLowerCase()), dom.DeclarationFlags.Optional);
     }
 

--- a/src/helpers/typingsHelper.ts
+++ b/src/helpers/typingsHelper.ts
@@ -35,7 +35,7 @@ export const AttributeTypeDefinitionMap = new Map<string, string>([
     ["Virtual","Attributes.Attribute"],
     ["BigInt","Attributes.NumberAttribute"],
     ["ManagedProperty", "Attributes.Attribute"],
-    ["EntityName","Attributes.Attribute"]
+    ["EntityName","Attributes.Attribute"],
     ]);
 
 const ControlTypeDefinitionMap = new Map<string, string>([
@@ -59,7 +59,7 @@ const ControlTypeDefinitionMap = new Map<string, string>([
     ["Virtual","Controls.Control"],
     ["BigInt","Controls.NumberControl"],
     ["ManagedProperty", "Controls.Control"],
-    ["EntityName","Controls.Control"]
+    ["EntityName","Controls.Control"],
     ]);
 export class TypingsHelper {
     /**
@@ -129,16 +129,21 @@ export class TypingsHelper {
     }
 
     private createAttributeMethod(attr: IAttributeDefinition): dom.MethodDeclaration {
-        return dom.create.method("getAttribute", [dom.create.parameter("name", dom.type.stringLiteral(camelize(attr.LogicalName)))], 
-        dom.create.namedTypeReference(AttributeTypeDefinitionMap.get(attr.AttributeType)??"Control.Attribute"));
-        //return dom.create.property(camelize(attr.LogicalName), this.convertType(attr.AttributeType.toLowerCase()), dom.DeclarationFlags.Optional);
+        let 
+        logicalNameParam = dom.create.parameter("name", dom.type.stringLiteral(camelize(attr.LogicalName))),
+        returnType = dom.create.namedTypeReference(AttributeTypeDefinitionMap.get(attr.AttributeType)||"Control.Attribute");
+
+        return dom.create.method("getAttribute",[logicalNameParam], returnType);
     }
 
     private createControlMethod(attr: IAttributeDefinition): dom.MethodDeclaration {
-        return dom.create.method("getControl", [dom.create.parameter("name", dom.type.stringLiteral(camelize(attr.LogicalName)))],  
-        dom.create.namedTypeReference(ControlTypeDefinitionMap.get(attr.AttributeType)??"Controls.Control"));
-        //return dom.create.property(camelize(attr.LogicalName), this.convertType(attr.AttributeType.toLowerCase()), dom.DeclarationFlags.Optional);
+        let 
+        logicalNameParam = dom.create.parameter("name", dom.type.stringLiteral(camelize(attr.LogicalName))),
+        returnType = dom.create.namedTypeReference(ControlTypeDefinitionMap.get(attr.AttributeType)||"Controls.Control");
+        
+        return dom.create.method("getControl", [logicalNameParam], returnType);
     }
+
 
     private createAttributeEnum(attrLogicalName: string, options: IOptionValue[]): dom.EnumDeclaration | undefined {
         const e = dom.create.enum(attrLogicalName, true, dom.DeclarationFlags.ReadOnly);

--- a/src/helpers/typingsHelper.ts
+++ b/src/helpers/typingsHelper.ts
@@ -14,7 +14,7 @@ const typingOmitAttribute = "Omit<FormContext, 'getAttribute'>";
 const typingOmitControl = "Omit<FormContext, 'getControl'>";
 const xrmAttribute = "Attributes.Attribute";
 const xrmControl = "Controls.StandardControl";
-export const AttributeTypeDefinitionMap = new Map<string, string>([
+export const AttributeTypeDefMap = new Map<string, string>([
     ["Boolean","Attributes.BooleanAttribute"],
     ["Customer","Attributes.LookupAttribute"],
     ["DateTime","Attributes.DateAttribute"],
@@ -38,7 +38,7 @@ export const AttributeTypeDefinitionMap = new Map<string, string>([
     ["EntityName","Attributes.Attribute"],
     ]);
 
-const ControlTypeDefinitionMap = new Map<string, string>([
+const ControlTypeDefMap = new Map<string, string>([
     ["Boolean","Controls.StandardControl"],
     ["Customer","Controls.LookupControl"],
     ["DateTime","Controls.DateControl"],
@@ -129,17 +129,17 @@ export class TypingsHelper {
     }
 
     private createAttributeMethod(attr: IAttributeDefinition): dom.MethodDeclaration {
-        let 
+        const 
         logicalNameParam = dom.create.parameter("name", dom.type.stringLiteral(camelize(attr.LogicalName))),
-        returnType = dom.create.namedTypeReference(AttributeTypeDefinitionMap.get(attr.AttributeType)||"Control.Attribute");
+        returnType = dom.create.namedTypeReference(AttributeTypeDefMap.get(attr.AttributeType)||"Control.Attribute");
 
         return dom.create.method("getAttribute",[logicalNameParam], returnType);
     }
 
     private createControlMethod(attr: IAttributeDefinition): dom.MethodDeclaration {
-        let 
+        const 
         logicalNameParam = dom.create.parameter("name", dom.type.stringLiteral(camelize(attr.LogicalName))),
-        returnType = dom.create.namedTypeReference(ControlTypeDefinitionMap.get(attr.AttributeType)||"Controls.Control");
+        returnType = dom.create.namedTypeReference(ControlTypeDefMap.get(attr.AttributeType)||"Controls.Control");
         
         return dom.create.method("getControl", [logicalNameParam], returnType);
     }

--- a/src/helpers/typingsHelper.ts
+++ b/src/helpers/typingsHelper.ts
@@ -5,7 +5,7 @@ import { camelize, pascalize, sanitize } from "../utils/ExtensionMethods";
 import { IAttributeDefinition, IOptionValue } from "../utils/Interfaces";
 import { getWorkspaceFolder, writeFileSync } from "../utils/FileSystem";
 import { Placeholders } from "../utils/Placeholders";
-import { AttributeTypeDefinitions, extensionName } from "../utils/Constants";
+import { AttributeTypeDefinitions, ControlTypeDefinitions , extensionName } from "../utils/Constants";
 
 const typingNamespace: string = "Xrm";
 const typingInterface: string = "EventContext";
@@ -83,12 +83,13 @@ export class TypingsHelper {
 
     private createAttributeMethod(attr: IAttributeDefinition): dom.MethodDeclaration {
         return dom.create.method("getAttribute", [dom.create.parameter("name", dom.type.stringLiteral(camelize(attr.LogicalName)))], 
-        dom.create.namedTypeReference(AttributeTypeDefinitions.get(attr.AttributeType)??"Xrm.Attributes.Attribute"));
+        dom.create.namedTypeReference(AttributeTypeDefinitions.get(attr.AttributeType)??"Xrm.Control.Attribute"));
         //return dom.create.property(camelize(attr.LogicalName), this.convertType(attr.AttributeType.toLowerCase()), dom.DeclarationFlags.Optional);
     }
 
     private createControlMethod(attr: IAttributeDefinition): dom.MethodDeclaration {
-        return dom.create.method("getControl", [dom.create.parameter("name", dom.type.stringLiteral(camelize(attr.LogicalName)))], dom.create.alias(xrmControl, dom.type.undefined, dom.DeclarationFlags.None));
+        return dom.create.method("getControl", [dom.create.parameter("name", dom.type.stringLiteral(camelize(attr.LogicalName)))],  
+        dom.create.namedTypeReference(ControlTypeDefinitions.get(attr.AttributeType)??"Xrm.Controls.Control"));
         //return dom.create.property(camelize(attr.LogicalName), this.convertType(attr.AttributeType.toLowerCase()), dom.DeclarationFlags.Optional);
     }
 

--- a/src/helpers/typingsHelper.ts
+++ b/src/helpers/typingsHelper.ts
@@ -5,7 +5,7 @@ import { camelize, pascalize, sanitize } from "../utils/ExtensionMethods";
 import { IAttributeDefinition, IOptionValue } from "../utils/Interfaces";
 import { getWorkspaceFolder, writeFileSync } from "../utils/FileSystem";
 import { Placeholders } from "../utils/Placeholders";
-import { extensionName } from "../utils/Constants";
+import { AttributeTypeDefinitions, extensionName } from "../utils/Constants";
 
 const typingNamespace: string = "Xrm";
 const typingInterface: string = "EventContext";
@@ -82,7 +82,8 @@ export class TypingsHelper {
     }
 
     private createAttributeMethod(attr: IAttributeDefinition): dom.MethodDeclaration {
-        return dom.create.method("getAttribute", [dom.create.parameter("name", dom.type.stringLiteral(camelize(attr.LogicalName)))], dom.create.alias(xrmAttribute, dom.type.undefined, dom.DeclarationFlags.None));
+        return dom.create.method("getAttribute", [dom.create.parameter("name", dom.type.stringLiteral(camelize(attr.LogicalName)))], 
+        dom.create.namedTypeReference(AttributeTypeDefinitions.get(attr.AttributeType)??"Xrm.Attributes.Attribute"));
         //return dom.create.property(camelize(attr.LogicalName), this.convertType(attr.AttributeType.toLowerCase()), dom.DeclarationFlags.Optional);
     }
 

--- a/src/helpers/typingsHelper.ts
+++ b/src/helpers/typingsHelper.ts
@@ -14,53 +14,53 @@ const typingOmitAttribute = "Omit<FormContext, 'getAttribute'>";
 const typingOmitControl = "Omit<FormContext, 'getControl'>";
 const xrmAttribute = "Attributes.Attribute";
 const xrmControl = "Controls.StandardControl";
-export const AttributeTypeDefMap = new Map<string, string>([
-    ["Boolean","Attributes.BooleanAttribute"],
-    ["Customer","Attributes.LookupAttribute"],
-    ["DateTime","Attributes.DateAttribute"],
-    ["Decimal","Attributes.NumberAttribute"],
-    ["Double","Attributes.NumberAttribute"],
-    ["Integer","Attributes.NumberAttribute"],
-    ["Lookup","Attributes.LookupAttribute"],
-    ["Memo","Attributes.StringAttribute"],
-    ["Money","Attributes.NumberAttribute"],
-    ["Owner","Attributes.LookupAttribute"],
-    ["PartyList","Attributes.LookupAttribute"],
+const attributeTypeDefMap = new Map<string, string>([
+    ["Boolean", "Attributes.BooleanAttribute"],
+    ["Customer", "Attributes.LookupAttribute"],
+    ["DateTime", "Attributes.DateAttribute"],
+    ["Decimal", "Attributes.NumberAttribute"],
+    ["Double", "Attributes.NumberAttribute"],
+    ["Integer", "Attributes.NumberAttribute"],
+    ["Lookup", "Attributes.LookupAttribute"],
+    ["Memo", "Attributes.StringAttribute"],
+    ["Money", "Attributes.NumberAttribute"],
+    ["Owner", "Attributes.LookupAttribute"],
+    ["PartyList", "Attributes.LookupAttribute"],
     ["Picklist", "Attributes.OptionSetAttribute"],
-    ["State","Attributes.OptionSetAttribute"],
-    ["Status","Attributes.OptionSetAttribute"],
-    ["String","Attributes.StringAttribute"],
-    ["Uniqueidentifier","Attributes.StringAttribute"],
-    ["CalendarRules","Attributes.Attribute"],
-    ["Virtual","Attributes.Attribute"],
-    ["BigInt","Attributes.NumberAttribute"],
+    ["State", "Attributes.OptionSetAttribute"],
+    ["Status", "Attributes.OptionSetAttribute"],
+    ["String", "Attributes.StringAttribute"],
+    ["Uniqueidentifier", "Attributes.StringAttribute"],
+    ["CalendarRules", "Attributes.Attribute"],
+    ["Virtual", "Attributes.Attribute"],
+    ["BigInt", "Attributes.NumberAttribute"],
     ["ManagedProperty", "Attributes.Attribute"],
-    ["EntityName","Attributes.Attribute"],
-    ]);
-
-const ControlTypeDefMap = new Map<string, string>([
-    ["Boolean","Controls.StandardControl"],
-    ["Customer","Controls.LookupControl"],
-    ["DateTime","Controls.DateControl"],
-    ["Decimal","Controls.NumberControl"],
-    ["Double","Controls.NumberControl"],
-    ["Integer","Controls.NumberControl"],
-    ["Lookup","Controls.LookupControl"],
-    ["Memo","Controls.StringControl"],
-    ["Money","Controls.NumberControl"],
-    ["Owner","Controls.LookupControl"],
-    ["PartyList","Controls.LookupControl"],
+    ["EntityName", "Attributes.Attribute"],
+]);
+const controlTypeDefMap = new Map<string, string>([
+    ["Boolean", "Controls.StandardControl"],
+    ["Customer", "Controls.LookupControl"],
+    ["DateTime", "Controls.DateControl"],
+    ["Decimal", "Controls.NumberControl"],
+    ["Double", "Controls.NumberControl"],
+    ["Integer", "Controls.NumberControl"],
+    ["Lookup", "Controls.LookupControl"],
+    ["Memo", "Controls.StringControl"],
+    ["Money", "Controls.NumberControl"],
+    ["Owner", "Controls.LookupControl"],
+    ["PartyList", "Controls.LookupControl"],
     ["Picklist", "Controls.OptionSetControl"],
-    ["State","Controls.OptionSetControl"],
-    ["Status","Controls.OptionSetControl"],
-    ["String","Controls.StringControl"],
-    ["Uniqueidentifier","Controls.StringControl"],
-    ["CalendarRules","Controls.Control"],
-    ["Virtual","Controls.Control"],
-    ["BigInt","Controls.NumberControl"],
+    ["State", "Controls.OptionSetControl"],
+    ["Status", "Controls.OptionSetControl"],
+    ["String", "Controls.StringControl"],
+    ["Uniqueidentifier", "Controls.StringControl"],
+    ["CalendarRules", "Controls.Control"],
+    ["Virtual", "Controls.Control"],
+    ["BigInt", "Controls.NumberControl"],
     ["ManagedProperty", "Controls.Control"],
-    ["EntityName","Controls.Control"],
-    ]);
+    ["EntityName", "Controls.Control"],
+]);
+
 export class TypingsHelper {
     /**
      * Initialization constructor for VS Code Context
@@ -129,21 +129,18 @@ export class TypingsHelper {
     }
 
     private createAttributeMethod(attr: IAttributeDefinition): dom.MethodDeclaration {
-        const 
-        logicalNameParam = dom.create.parameter("name", dom.type.stringLiteral(camelize(attr.LogicalName))),
-        returnType = dom.create.namedTypeReference(AttributeTypeDefMap.get(attr.AttributeType)||"Control.Attribute");
+        const logicalNameParam = dom.create.parameter("name", dom.type.stringLiteral(camelize(attr.LogicalName)));
+        const returnType = dom.create.namedTypeReference(attributeTypeDefMap.get(attr.AttributeType) || xrmAttribute);
 
-        return dom.create.method("getAttribute",[logicalNameParam], returnType);
+        return dom.create.method("getAttribute", [logicalNameParam], returnType);
     }
 
     private createControlMethod(attr: IAttributeDefinition): dom.MethodDeclaration {
-        const 
-        logicalNameParam = dom.create.parameter("name", dom.type.stringLiteral(camelize(attr.LogicalName))),
-        returnType = dom.create.namedTypeReference(ControlTypeDefMap.get(attr.AttributeType)||"Controls.Control");
-        
+        const logicalNameParam = dom.create.parameter("name", dom.type.stringLiteral(camelize(attr.LogicalName)));
+        const returnType = dom.create.namedTypeReference(controlTypeDefMap.get(attr.AttributeType) || xrmControl);
+
         return dom.create.method("getControl", [logicalNameParam], returnType);
     }
-
 
     private createAttributeEnum(attrLogicalName: string, options: IOptionValue[]): dom.EnumDeclaration | undefined {
         const e = dom.create.enum(attrLogicalName, true, dom.DeclarationFlags.ReadOnly);

--- a/src/utils/Constants.ts
+++ b/src/utils/Constants.ts
@@ -26,6 +26,30 @@ export const fileExtensions: string[] = [".js", ".html", ".css"];
 export const portADFS: number = 29827;
 export const redirectUrl: string = `http://localhost:${portADFS}/callback/`;
 export const configSectionName: string = "dataverse-devtools";
+export const AttributeTypeDefinitions = new Map<string, string>([
+    ["Boolean","Xrm.Attributes.BooleanAttribute"],
+    ["Customer","Xrm.Attributes.LookupAttribute"],
+    ["DateTime","Xrm.Attributes.DateAttribute"],
+    ["Decimal","Xrm.Attributes.NumberAttribute"],
+    ["Double","Xrm.Attributes.NumberAttribute"],
+    ["Integer","Xrm.Attributes.NumberAttribute"],
+    ["Lookup","Xrm.Attributes.LookupAttribute"],
+    ["Memo","Xrm.Attributes.StringAttribute"],
+    ["Money","Xrm.Attributes.NumberAttribute"],
+    ["Owner","Xrm.Attributes.LookupAttribute"],
+    ["PartyList","Xrm.Attributes.LookupAttribute"],
+    ["Picklist", "Xrm.Attributes.OptionSetAttribute"],
+    ["State","Xrm.Attributes.OptionSetAttribute"],
+    ["Status","Xrm.Attributes.OptionSetAttribute"],
+    ["String","Xrm.Attributes.StringAttribute"],
+    ["Uniqueidentifier","Xrm.Attributes.StringAttribute"],
+    ["CalendarRules","Xrm.Attributes.Attribute"],
+    ["Virtual","Xrm.Attributes.Attribute"],
+    ["BigInt","Xrm.Attributes.NumberAttribute"],
+    ["ManagedProperty", "ManagedProperty"],
+    ["EntityName","Xrm.Attributes.Attribute"]
+    ]);
+    
 
 export enum WebResourceType {
     html = 1,

--- a/src/utils/Constants.ts
+++ b/src/utils/Constants.ts
@@ -27,28 +27,52 @@ export const portADFS: number = 29827;
 export const redirectUrl: string = `http://localhost:${portADFS}/callback/`;
 export const configSectionName: string = "dataverse-devtools";
 export const AttributeTypeDefinitions = new Map<string, string>([
-    ["Boolean","Xrm.Attributes.BooleanAttribute"],
-    ["Customer","Xrm.Attributes.LookupAttribute"],
-    ["DateTime","Xrm.Attributes.DateAttribute"],
-    ["Decimal","Xrm.Attributes.NumberAttribute"],
-    ["Double","Xrm.Attributes.NumberAttribute"],
-    ["Integer","Xrm.Attributes.NumberAttribute"],
-    ["Lookup","Xrm.Attributes.LookupAttribute"],
-    ["Memo","Xrm.Attributes.StringAttribute"],
-    ["Money","Xrm.Attributes.NumberAttribute"],
-    ["Owner","Xrm.Attributes.LookupAttribute"],
-    ["PartyList","Xrm.Attributes.LookupAttribute"],
-    ["Picklist", "Xrm.Attributes.OptionSetAttribute"],
-    ["State","Xrm.Attributes.OptionSetAttribute"],
-    ["Status","Xrm.Attributes.OptionSetAttribute"],
-    ["String","Xrm.Attributes.StringAttribute"],
-    ["Uniqueidentifier","Xrm.Attributes.StringAttribute"],
-    ["CalendarRules","Xrm.Attributes.Attribute"],
-    ["Virtual","Xrm.Attributes.Attribute"],
-    ["BigInt","Xrm.Attributes.NumberAttribute"],
-    ["ManagedProperty", "ManagedProperty"],
-    ["EntityName","Xrm.Attributes.Attribute"]
+    ["Boolean","Attributes.BooleanAttribute"],
+    ["Customer","Attributes.LookupAttribute"],
+    ["DateTime","Attributes.DateAttribute"],
+    ["Decimal","Attributes.NumberAttribute"],
+    ["Double","Attributes.NumberAttribute"],
+    ["Integer","Attributes.NumberAttribute"],
+    ["Lookup","Attributes.LookupAttribute"],
+    ["Memo","Attributes.StringAttribute"],
+    ["Money","Attributes.NumberAttribute"],
+    ["Owner","Attributes.LookupAttribute"],
+    ["PartyList","Attributes.LookupAttribute"],
+    ["Picklist", "Attributes.OptionSetAttribute"],
+    ["State","Attributes.OptionSetAttribute"],
+    ["Status","Attributes.OptionSetAttribute"],
+    ["String","Attributes.StringAttribute"],
+    ["Uniqueidentifier","Attributes.StringAttribute"],
+    ["CalendarRules","Attributes.Attribute"],
+    ["Virtual","Attributes.Attribute"],
+    ["BigInt","Attributes.NumberAttribute"],
+    ["ManagedProperty", "Attributes.Attribute"],
+    ["EntityName","Attributes.Attribute"]
     ]);
+
+    export const ControlTypeDefinitions = new Map<string, string>([
+        ["Boolean","Controls.StandardControl"],
+        ["Customer","Controls.LookupControl"],
+        ["DateTime","Controls.DateControl"],
+        ["Decimal","Controls.NumberControl"],
+        ["Double","Controls.NumberControl"],
+        ["Integer","Controls.NumberControl"],
+        ["Lookup","Controls.LookupControl"],
+        ["Memo","Controls.StringControl"],
+        ["Money","Controls.NumberControl"],
+        ["Owner","Controls.LookupControl"],
+        ["PartyList","Controls.LookupControl"],
+        ["Picklist", "Controls.OptionSetControl"],
+        ["State","Controls.OptionSetControl"],
+        ["Status","Controls.OptionSetControl"],
+        ["String","Controls.StringControl"],
+        ["Uniqueidentifier","Controls.StringControl"],
+        ["CalendarRules","Controls.Control"],
+        ["Virtual","Controls.Control"],
+        ["BigInt","Controls.NumberControl"],
+        ["ManagedProperty", "Controls.Control"],
+        ["EntityName","Controls.Control"]
+        ]);
     
 
 export enum WebResourceType {

--- a/src/utils/Constants.ts
+++ b/src/utils/Constants.ts
@@ -26,54 +26,6 @@ export const fileExtensions: string[] = [".js", ".html", ".css"];
 export const portADFS: number = 29827;
 export const redirectUrl: string = `http://localhost:${portADFS}/callback/`;
 export const configSectionName: string = "dataverse-devtools";
-export const AttributeTypeDefinitions = new Map<string, string>([
-    ["Boolean","Attributes.BooleanAttribute"],
-    ["Customer","Attributes.LookupAttribute"],
-    ["DateTime","Attributes.DateAttribute"],
-    ["Decimal","Attributes.NumberAttribute"],
-    ["Double","Attributes.NumberAttribute"],
-    ["Integer","Attributes.NumberAttribute"],
-    ["Lookup","Attributes.LookupAttribute"],
-    ["Memo","Attributes.StringAttribute"],
-    ["Money","Attributes.NumberAttribute"],
-    ["Owner","Attributes.LookupAttribute"],
-    ["PartyList","Attributes.LookupAttribute"],
-    ["Picklist", "Attributes.OptionSetAttribute"],
-    ["State","Attributes.OptionSetAttribute"],
-    ["Status","Attributes.OptionSetAttribute"],
-    ["String","Attributes.StringAttribute"],
-    ["Uniqueidentifier","Attributes.StringAttribute"],
-    ["CalendarRules","Attributes.Attribute"],
-    ["Virtual","Attributes.Attribute"],
-    ["BigInt","Attributes.NumberAttribute"],
-    ["ManagedProperty", "Attributes.Attribute"],
-    ["EntityName","Attributes.Attribute"]
-    ]);
-
-    export const ControlTypeDefinitions = new Map<string, string>([
-        ["Boolean","Controls.StandardControl"],
-        ["Customer","Controls.LookupControl"],
-        ["DateTime","Controls.DateControl"],
-        ["Decimal","Controls.NumberControl"],
-        ["Double","Controls.NumberControl"],
-        ["Integer","Controls.NumberControl"],
-        ["Lookup","Controls.LookupControl"],
-        ["Memo","Controls.StringControl"],
-        ["Money","Controls.NumberControl"],
-        ["Owner","Controls.LookupControl"],
-        ["PartyList","Controls.LookupControl"],
-        ["Picklist", "Controls.OptionSetControl"],
-        ["State","Controls.OptionSetControl"],
-        ["Status","Controls.OptionSetControl"],
-        ["String","Controls.StringControl"],
-        ["Uniqueidentifier","Controls.StringControl"],
-        ["CalendarRules","Controls.Control"],
-        ["Virtual","Controls.Control"],
-        ["BigInt","Controls.NumberControl"],
-        ["ManagedProperty", "Controls.Control"],
-        ["EntityName","Controls.Control"]
-        ]);
-    
 
 export enum WebResourceType {
     html = 1,


### PR DESCRIPTION
Based on [discussion #38](https://github.com/Power-Maverick/DataverseDevTools-VSCode/discussions/38)
Purpose is to map the AttributeType on IAttributeDefinition to a suitable Xrm.Attributes and Xrm.Controls Interface when generating the typings for entities. 


Originally had Type Definition Maps in utils/Constants but realized that made no sense as it has no global relevance.
Moved all changes to typingsHelpers.  Using a Map<string, string> to hold mapping which I saw as the most straightforward way to map a string to a string. 

Using `dom.create.namedTypeReference` to create the typing as I am largely unfamiliar with the `dts-dom` library though I assume this would be the correct way of doing it. Though if not please correct but this does work to set the typings. 

