### PR TITLE
fixes  #213

### DIFF
--- a/resources/templates/Webpack/webpack.config.dev.js
+++ b/resources/templates/Webpack/webpack.config.dev.js
@@ -2,6 +2,7 @@ const { merge } = require("webpack-merge");
 const sharedConfig = require("./webpack.config");
 module.exports = merge(sharedConfig, {
     mode: "development",
+    devtool: "source-map",
     optimization: {
         minimize: false,
     },

--- a/resources/templates/Webpack/webpack.config.js
+++ b/resources/templates/Webpack/webpack.config.js
@@ -1,7 +1,6 @@
 const path = require("path");
 const { CleanWebpackPlugin } = require("clean-webpack-plugin");
 module.exports = {
-    devtool: "source-map",
     entry: {
     },
     output: {


### PR DESCRIPTION
The source map is only useful when debugging, and will typically not be deployed as a web resource to the Power Platform solution. 
Generating it for production builds means that the reference to the *.js.map file will be included in the deployed JS file which causes "file not found". Not a biggie =) but not pretty either ;)