### PR TITLE
Add plugin sync via pac plugin push

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,6 +120,16 @@
                     "command": "dvdt.explorer.webresources.compareWebResource",
                     "when": "resourceExtname in devtools.resourcesExtn && resourceFilename in devtools.linkedResources",
                     "group": "%dvdt.menus.group.wr%@3"
+                },
+                {
+                    "command": "dvdt.explorer.plugins.linkPlugin",
+                    "when": "resourceExtname == .csproj",
+                    "group": "%dvdt.menus.group.plugin%@1"
+                },
+                {
+                    "command": "dvdt.explorer.plugins.pushPlugin",
+                    "when": "resourceExtname == .csproj",
+                    "group": "%dvdt.menus.group.plugin%@2"
                 }
             ],
             "view/title": [
@@ -523,6 +533,18 @@
                     "light": "resources/light/play.svg",
                     "dark": "resources/dark/play.svg"
                 }
+            },
+            {
+                "command": "dvdt.explorer.plugins.linkPlugin",
+                "title": "Link to Existing Dataverse Plugin",
+                "when": "false",
+                "category": "%dvdt.explorer.category%"
+            },
+            {
+                "command": "dvdt.explorer.plugins.pushPlugin",
+                "title": "Push Plugin to Dataverse",
+                "when": "false",
+                "category": "%dvdt.explorer.category%"
             }
         ],
         "configuration": {

--- a/package.nls.json
+++ b/package.nls.json
@@ -3,6 +3,7 @@
     "dvdt.explorer.category": "Explorer",
     "dvdt.menus.group.ts": "dvdevtools-ts",
     "dvdt.menus.group.wr": "dvdevtools-wr",
+    "dvdt.menus.group.plugin": "dvdevtools-plugin",
     "dvdt.config.title": "Dataverse DevTools",
     "dvdt.config.enablePreview": "Enable a preview features for Dataverse DevTools. See [documentation for all available preview features](https://github.com/Power-Maverick/DataverseDevTools-VSCode#-early-access-preview).\n\n> _Note: these features are not fully tested; so if you encounter any bugs please report them on GitHub (your name will appear on the contributors list)._",
     "dvdt.config.defaultTSTemplate": "Specifies how Dataverse DevTools should behave when you initiate a TypeScript project. This will skip the extra question during TS project initialization when you either select `Plain TypeScript` or `Webpack`"

--- a/resources/templates/dvdt.linker.xml
+++ b/resources/templates/dvdt.linker.xml
@@ -2,6 +2,8 @@
 <DVDT>
     <WebResources>
     </WebResources>
+    <Plugins>
+    </Plugins>
     <Settings>
     </Settings>
 </DVDT>

--- a/src/commands/registerCommands.ts
+++ b/src/commands/registerCommands.ts
@@ -4,6 +4,7 @@ import { CliCommandTreeItem } from "../cliCommands/cliCommandsDataProvider";
 import { CLIHelper } from "../helpers/cliHelper";
 import { DataverseHelper } from "../helpers/dataverseHelper";
 import { ErrorHandler } from "../helpers/errorHandler";
+import { PluginHelper } from "../helpers/pluginHelper";
 import { TemplateHelper } from "../helpers/templateHelper";
 import { ToolsHelper } from "../helpers/toolsHelper";
 import { TypingsHelper } from "../helpers/typingsHelper";
@@ -29,6 +30,7 @@ export async function registerCommands(vscontext: vscode.ExtensionContext, tr: T
     const cliHelper = new CLIHelper(vscontext);
     const templateHelper = new TemplateHelper(vscontext);
     const wrHelper = new WebResourceHelper(vscontext, dvHelper);
+    const pluginHelper = new PluginHelper(vscontext);
     const typingHelper = new TypingsHelper(vscontext, dvHelper);
     const errorHandler = new ErrorHandler(tr);
     const toolsHelper = new ToolsHelper(vscontext);
@@ -253,6 +255,26 @@ export async function registerCommands(vscontext: vscode.ExtensionContext, tr: T
                 }
             },
         },
+        {
+            command: "dvdt.explorer.plugins.linkPlugin",
+            callback: async (uri: vscode.Uri) => {
+                try {
+                    await pluginHelper.linkPlugin(uri.fsPath);
+                } catch (error) {
+                    errorHandler.log(error, "linkPlugin");
+                }
+            },
+        },
+        {
+            command: "dvdt.explorer.plugins.pushPlugin",
+            callback: async (uri: vscode.Uri) => {
+                try {
+                    await pluginHelper.pushPlugin(uri.fsPath);
+                } catch (error) {
+                    errorHandler.log(error, "pushPlugin");
+                }
+            },
+        },
     );
     cmds.forEach((c) => {
         vscontext.subscriptions.push(vscode.commands.registerCommand(c.command, c.callback));
@@ -260,6 +282,7 @@ export async function registerCommands(vscontext: vscode.ExtensionContext, tr: T
 
     updateConnectionStatusBar(await dvHelper.reloadWorkspaceConnection());
     vscode.commands.executeCommand("setContext", `${extensionPrefix}.linkedResources`, await wrHelper.getLinkedResourceStrings("@_localFileName"));
+    vscode.commands.executeCommand("setContext", `${extensionPrefix}.linkedPlugins`, await pluginHelper.getLinkedProjectPaths());
 }
 
 /**

--- a/src/helpers/dataverseHelper.ts
+++ b/src/helpers/dataverseHelper.ts
@@ -10,6 +10,8 @@ import {
     customDataverseClientId,
     entityDefinitionsStoreKey,
     environmentTypes,
+    pluginAssembliesStoreKey,
+    pluginPackagesStoreKey,
     reservedWords,
     solDefinitionsStoreKey,
     wrDefinitionsStoreKey,
@@ -24,6 +26,8 @@ import {
     IEntityMetadata,
     IOptionSet,
     IOptionSetMetadata,
+    IPluginAssemblies,
+    IPluginPackages,
     ISolutionComponents,
     ISolutions,
     IWebResource,
@@ -145,8 +149,8 @@ export class DataverseHelper {
                     this.vsstate.saveInWorkspace(connectionCurrentStoreKey, conn);
                     progress.report({ increment: 30, message: "Getting entity metadata..." });
                     await this.getEntityDefinitions();
-                    progress.report({ increment: 70, message: "Getting web resources..." });
-                    await this.getWebResources();
+                    progress.report({ increment: 70, message: "Getting web resources & plugins..." });
+                    await Promise.all([this.getWebResources(), this.getPluginAssemblies(), this.getPluginPackages()]);
 
                     vscode.commands.executeCommand("dvdt.explorer.connections.refreshConnection");
                     return new Promise<IConnection>((resolve) => {
@@ -178,7 +182,7 @@ export class DataverseHelper {
         const connFromWS: IConnection = this.vsstate.getFromWorkspace(connectionCurrentStoreKey);
         if (connFromWS) {
             await this.getEntityDefinitions();
-            await this.getWebResources();
+            await Promise.all([this.getWebResources(), this.getPluginAssemblies(), this.getPluginPackages()]);
             return connFromWS;
         }
         return undefined;
@@ -339,6 +343,24 @@ export class DataverseHelper {
         const respData = await this.request.requestData<IWebResources>("webresourceset?$filter=(ismanaged%20eq%20false%20and%20iscustomizable/Value%20eq%20true%20)");
         this.vsstate.saveInWorkspace(wrDefinitionsStoreKey, respData);
         vscode.commands.executeCommand("dvdt.explorer.webresources.loadWebResources");
+    }
+
+    /**
+     * Get plugin assemblies (unmanaged) from the current connection.
+     */
+    public async getPluginAssemblies(): Promise<IPluginAssemblies | undefined> {
+        const respData = await this.request.requestData<IPluginAssemblies>("pluginassemblies?$select=pluginassemblyid,name&$filter=ismanaged%20eq%20false%20and%20_packageid_value%20eq%20null");
+        this.vsstate.saveInWorkspace(pluginAssembliesStoreKey, respData);
+        return respData;
+    }
+
+    /**
+     * Get plugin packages (unmanaged) from the current connection.
+     */
+    public async getPluginPackages(): Promise<IPluginPackages | undefined> {
+        const respData = await this.request.requestData<IPluginPackages>("pluginpackages?$select=pluginpackageid,name&$filter=ismanaged%20eq%20false");
+        this.vsstate.saveInWorkspace(pluginPackagesStoreKey, respData);
+        return respData;
     }
 
     /**

--- a/src/helpers/pluginHelper.ts
+++ b/src/helpers/pluginHelper.ts
@@ -1,0 +1,310 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+import { spawn } from "child_process";
+import * as path from "path";
+import * as vscode from "vscode";
+import { connectionCurrentStoreKey, extensionPrefix, pluginAssembliesStoreKey, pluginPackagesStoreKey, PluginType } from "../utils/Constants";
+import { ErrorMessages } from "../utils/ErrorMessages";
+import { copyFolderOrFile, getRelativeFilePath, getWorkspaceFolder, readFileSync, writeFileSync } from "../utils/FileSystem";
+import { IConnection, ILinkerFile, ILinkerPlugin, IPluginAssemblies, IPluginPackages } from "../utils/Interfaces";
+import { jsonToXML, xmlToJSON } from "../utils/Parsers";
+import { Placeholders } from "../utils/Placeholders";
+import { State } from "../utils/State";
+
+interface IPluginQuickPickItem extends vscode.QuickPickItem {
+    id: string;
+    name: string;
+    type: PluginType;
+}
+
+interface ILookupResult {
+    entry: ILinkerPlugin;
+    index: number;
+}
+
+export class PluginHelper {
+    private vsstate: State;
+    private static outputChannel: vscode.OutputChannel | undefined;
+
+    constructor(private vscontext: vscode.ExtensionContext) {
+        this.vsstate = new State(vscontext);
+    }
+
+    //#region Public
+
+    public async linkPlugin(csprojFullPath: string): Promise<ILinkerPlugin | undefined> {
+        const assemblies: IPluginAssemblies = this.vsstate.getFromWorkspace(pluginAssembliesStoreKey);
+        const packages: IPluginPackages = this.vsstate.getFromWorkspace(pluginPackagesStoreKey);
+        const conn: IConnection = this.vsstate.getFromWorkspace(connectionCurrentStoreKey);
+
+        if (!conn) {
+            vscode.window.showErrorMessage("Connect to a Dataverse environment before linking a plugin.");
+            return undefined;
+        }
+
+        const items: IPluginQuickPickItem[] = [];
+        if (assemblies && assemblies.value) {
+            assemblies.value.forEach((a) => items.push({ label: a.name, description: "Assembly", id: a.pluginassemblyid, name: a.name, type: PluginType.assembly }));
+        }
+        if (packages && packages.value) {
+            packages.value.forEach((p) => items.push({ label: p.name, description: "Package", id: p.pluginpackageid, name: p.name, type: PluginType.nuget }));
+        }
+
+        if (items.length === 0) {
+            vscode.window.showErrorMessage(ErrorMessages.pluginListUnavailable);
+            return undefined;
+        }
+
+        const qpOptions = Placeholders.getQuickPickOptions(Placeholders.pluginSelection);
+        const picked = await vscode.window.showQuickPick(items, qpOptions);
+        if (!picked) {
+            return undefined;
+        }
+
+        const localRelativePath = getRelativeFilePath(csprojFullPath, getWorkspaceFolder()?.fsPath!);
+        const existing = await this.lookupLinkedPlugin(csprojFullPath);
+
+        const newEntry: ILinkerPlugin = {
+            "@_Id": picked.id,
+            "@_dvName": picked.name,
+            "@_type": picked.type,
+            "@_localProjectPath": localRelativePath,
+            "@_environment": conn.environmentUrl.replace(/\/+$/, ""),
+        };
+
+        if (existing) {
+            const confirm = await vscode.window.showWarningMessage("This project is already linked. Re-link?", { detail: "Confirm your selection", modal: true }, "Yes", "No");
+            if (confirm !== "Yes") {
+                return undefined;
+            }
+            return await this.updateInLinkerFile(existing.index, newEntry);
+        }
+
+        return await this.addInLinkerFile(newEntry);
+    }
+
+    public async pushPlugin(csprojFullPath: string): Promise<void> {
+        let linked = await this.lookupLinkedPlugin(csprojFullPath);
+        if (!linked) {
+            const linkOptions = ["Link to existing plugin & push"];
+            const qpOptions = Placeholders.getQuickPickOptions(Placeholders.pluginLinkSelection);
+            const choice = await vscode.window.showQuickPick(linkOptions, qpOptions);
+            if (!choice) {
+                return;
+            }
+            const newEntry = await this.linkPlugin(csprojFullPath);
+            if (!newEntry) {
+                return;
+            }
+            linked = { entry: newEntry, index: 0 };
+        }
+
+        const projectDir = path.dirname(csprojFullPath);
+        const projectName = path.basename(csprojFullPath);
+        const entry = linked.entry;
+
+        const authed = await this.ensurePacAuth(entry["@_environment"]);
+        if (!authed) {
+            return;
+        }
+
+        const args = ["plugin", "push", "--pluginId", entry["@_Id"], "--type", entry["@_type"], "--environment", entry["@_environment"]];
+
+        const channel = PluginHelper.getOutputChannel();
+        channel.clear();
+        channel.appendLine(`> pac ${args.join(" ")}`);
+        channel.appendLine(`> cwd: ${projectDir}`);
+        channel.appendLine("");
+
+        await vscode.window.withProgress(
+            {
+                location: vscode.ProgressLocation.Notification,
+                title: `Pushing ${projectName}`,
+                cancellable: false,
+            },
+            async (progress) => {
+                progress.report({ message: "Running pac plugin push..." });
+
+                const exitCode = await new Promise<number>((resolve) => {
+                    const child = spawn("pac", args, { cwd: projectDir, shell: true });
+
+                    child.stdout.on("data", (data: Buffer) => channel.append(data.toString()));
+                    child.stderr.on("data", (data: Buffer) => channel.append(data.toString()));
+                    child.on("error", (err) => {
+                        channel.appendLine(`\nFailed to start pac: ${err.message}`);
+                        resolve(-1);
+                    });
+                    child.on("close", (code) => resolve(code ?? -1));
+                });
+
+                if (exitCode === 0) {
+                    vscode.window.showInformationMessage(`${projectName} pushed.`);
+                } else {
+                    channel.show(true);
+                    vscode.window.showErrorMessage(ErrorMessages.pluginPushFailed);
+                }
+            },
+        );
+    }
+
+    public async getLinkedProjectPaths(): Promise<string[] | undefined> {
+        const linkerFile = await this.getLinkerFile();
+        if (!linkerFile) {
+            return undefined;
+        }
+        const data = readFileSync(linkerFile.fsPath).toString();
+        const json = xmlToJSON<ILinkerFile>(data);
+        if (!json.DVDT.Plugins || !json.DVDT.Plugins.Plugin) {
+            return [];
+        }
+        if (Array.isArray(json.DVDT.Plugins.Plugin)) {
+            return json.DVDT.Plugins.Plugin.map((p) => p["@_localProjectPath"]);
+        }
+        return [json.DVDT.Plugins.Plugin["@_localProjectPath"]];
+    }
+
+    //#endregion Public
+
+    //#region Private
+
+    private async ensurePacAuth(environment: string): Promise<boolean> {
+        if (!(await this.isPacInstalled())) {
+            const choice = await vscode.window.showErrorMessage("Power Platform CLI (pac) was not found. Install it and try again.", "Open install docs");
+            if (choice === "Open install docs") {
+                vscode.env.openExternal(vscode.Uri.parse("https://aka.ms/PowerPlatformCLI"));
+            }
+            return false;
+        }
+
+        if (await this.hasPacProfileForEnv(environment)) {
+            return true;
+        }
+
+        const choice = await vscode.window.showWarningMessage(`pac is not authenticated to ${environment}. Authenticate first, then try Push again.`, "Authenticate");
+        if (choice === "Authenticate") {
+            const terminal = vscode.window.createTerminal("DVDT - pac auth");
+            terminal.show();
+            terminal.sendText(`pac auth create --environment "${environment}"`, false);
+        }
+        return false;
+    }
+
+    private async isPacInstalled(): Promise<boolean> {
+        return new Promise<boolean>((resolve) => {
+            const child = spawn("pac", [], { shell: true });
+            child.on("close", (code) => resolve(code === 0));
+            child.on("error", () => resolve(false));
+        });
+    }
+
+    private async hasPacProfileForEnv(environment: string): Promise<boolean> {
+        const output = await new Promise<string>((resolve) => {
+            let buf = "";
+            const child = spawn("pac", ["auth", "list"], { shell: true });
+            child.stdout.on("data", (d: Buffer) => (buf += d.toString()));
+            child.stderr.on("data", (d: Buffer) => (buf += d.toString()));
+            child.on("close", () => resolve(buf));
+            child.on("error", () => resolve(""));
+        });
+        const normalize = (u: string) => u.replace(/\/+$/, "").toLowerCase();
+        return normalize(output).includes(normalize(environment));
+    }
+
+    private async lookupLinkedPlugin(csprojFullPath: string): Promise<ILookupResult | undefined> {
+        const linkerFile = await this.getLinkerFile();
+        if (!linkerFile) {
+            return undefined;
+        }
+        const localRelativePath = getRelativeFilePath(csprojFullPath, getWorkspaceFolder()?.fsPath!);
+        const data = readFileSync(linkerFile.fsPath).toString();
+        const json = xmlToJSON<ILinkerFile>(data);
+
+        if (!json.DVDT.Plugins || !json.DVDT.Plugins.Plugin) {
+            return undefined;
+        }
+
+        if (Array.isArray(json.DVDT.Plugins.Plugin)) {
+            const idx = json.DVDT.Plugins.Plugin.findIndex((p) => p["@_localProjectPath"] === localRelativePath);
+            return idx >= 0 ? { entry: json.DVDT.Plugins.Plugin[idx], index: idx } : undefined;
+        } else {
+            return json.DVDT.Plugins.Plugin["@_localProjectPath"] === localRelativePath ? { entry: json.DVDT.Plugins.Plugin, index: 0 } : undefined;
+        }
+    }
+
+    private async addInLinkerFile(entry: ILinkerPlugin): Promise<ILinkerPlugin | undefined> {
+        const linkerFile = await this.createLinkerFile();
+        if (!linkerFile) {
+            return undefined;
+        }
+        const data = readFileSync(linkerFile.fsPath).toString();
+        const json = xmlToJSON<ILinkerFile>(data);
+
+        if (!json.DVDT.Plugins) {
+            json.DVDT.Plugins = { Plugin: [] };
+        }
+        if (Array.isArray(json.DVDT.Plugins.Plugin)) {
+            json.DVDT.Plugins.Plugin.push(entry);
+        } else {
+            const existing = json.DVDT.Plugins.Plugin;
+            json.DVDT.Plugins.Plugin = [existing, entry];
+        }
+        writeFileSync(linkerFile.fsPath, jsonToXML(json));
+        await this.updateLinkedPluginsContext();
+        return entry;
+    }
+
+    private async updateInLinkerFile(oldIndex: number, newEntry: ILinkerPlugin): Promise<ILinkerPlugin | undefined> {
+        const linkerFile = await this.getLinkerFile();
+        if (!linkerFile) {
+            return undefined;
+        }
+        const data = readFileSync(linkerFile.fsPath).toString();
+        const json = xmlToJSON<ILinkerFile>(data);
+
+        if (!json.DVDT.Plugins) {
+            return undefined;
+        }
+        if (Array.isArray(json.DVDT.Plugins.Plugin)) {
+            json.DVDT.Plugins.Plugin[oldIndex] = newEntry;
+        } else {
+            json.DVDT.Plugins.Plugin = newEntry;
+        }
+        writeFileSync(linkerFile.fsPath, jsonToXML(json));
+        await this.updateLinkedPluginsContext();
+        return newEntry;
+    }
+
+    private async getLinkerFile(): Promise<vscode.Uri | undefined> {
+        const files = await vscode.workspace.findFiles("**/dvdt.linker.xml", "**/node_modules/**");
+        return files.length > 0 ? files[0] : undefined;
+    }
+
+    private async createLinkerFile(): Promise<vscode.Uri | undefined> {
+        if (!vscode.workspace.workspaceFolders) {
+            return undefined;
+        }
+        const existing = await this.getLinkerFile();
+        if (existing) {
+            return existing;
+        }
+        const workspaceFolder = vscode.workspace.workspaceFolders[0].uri;
+        const extPath = this.vscontext.extensionUri.fsPath;
+        const linkerTemplate = path.join(extPath, "resources", "templates", "dvdt.linker.xml");
+        const newLinkerFileUri = vscode.Uri.joinPath(workspaceFolder, "dvdt.linker.xml");
+        await copyFolderOrFile(linkerTemplate, newLinkerFileUri.fsPath);
+        return newLinkerFileUri;
+    }
+
+    private async updateLinkedPluginsContext(): Promise<void> {
+        const paths = await this.getLinkedProjectPaths();
+        await vscode.commands.executeCommand("setContext", `${extensionPrefix}.linkedPlugins`, paths);
+    }
+
+    private static getOutputChannel(): vscode.OutputChannel {
+        if (!PluginHelper.outputChannel) {
+            PluginHelper.outputChannel = vscode.window.createOutputChannel("Dataverse DevTools - Plugin Push");
+        }
+        return PluginHelper.outputChannel;
+    }
+
+    //#endregion Private
+}

--- a/src/utils/Constants.ts
+++ b/src/utils/Constants.ts
@@ -15,6 +15,8 @@ export const connectionStoreKey: string = `DataverseConnections`;
 export const connectionCurrentStoreKey: string = `LiveDVConnection`;
 export const entityDefinitionsStoreKey: string = `CurrentEntityDefinitions`;
 export const wrDefinitionsStoreKey: string = `CurrentWRs`;
+export const pluginAssembliesStoreKey: string = `CurrentPluginAssemblies`;
+export const pluginPackagesStoreKey: string = `CurrentPluginPackages`;
 export const solDefinitionsStoreKey: string = `CurrentSolutions`;
 export const smartMatchStoreKey: string = `CurrentSmartMatch`;
 export const environmentTypes: string[] = ["Dev", "QA", "UAT", "Prod"];
@@ -50,6 +52,11 @@ export enum WebResourceType {
     svg = 11,
     resx = 12,
     others = -1,
+}
+
+export enum PluginType {
+    assembly = "Assembly",
+    nuget = "Nuget",
 }
 
 export enum ConfidenceScores {

--- a/src/utils/ErrorMessages.ts
+++ b/src/utils/ErrorMessages.ts
@@ -16,4 +16,6 @@ export class ErrorMessages {
     public static drbConnectionError: string = "Connect to an environment before trying to load Dataverse REST Builder.";
     public static invalidLoginType: string = "Invalid Login Type.";
     public static commonToolsError: string = "An error occurred while trying to open the tool. Please try again.";
+    public static pluginPushFailed: string = "Failed to push plugin. See the 'Dataverse DevTools - Plugin Push' output channel for details.";
+    public static pluginListUnavailable: string = "No plugin assemblies or packages found in the connected environment.";
 }

--- a/src/utils/Interfaces.ts
+++ b/src/utils/Interfaces.ts
@@ -193,6 +193,7 @@ export interface ILinkerFile {
 
 export interface ILinkerRoot {
     WebResources: ILinkerResources;
+    Plugins?: ILinkerPlugins;
     Settings: any[];
 }
 
@@ -206,6 +207,36 @@ export interface ILinkerRes {
     "@_dvDisplayName": string;
     "@_dvFilePath": string;
     "@_Id": string;
+}
+
+export interface ILinkerPlugins {
+    Plugin: Array<ILinkerPlugin> | ILinkerPlugin;
+}
+
+export interface ILinkerPlugin {
+    "@_Id": string;
+    "@_dvName": string;
+    "@_type": string;
+    "@_localProjectPath": string;
+    "@_environment": string;
+}
+
+export interface IPluginAssemblies {
+    value: IPluginAssembly[];
+}
+
+export interface IPluginAssembly {
+    pluginassemblyid: string;
+    name: string;
+}
+
+export interface IPluginPackages {
+    value: IPluginPackage[];
+}
+
+export interface IPluginPackage {
+    pluginpackageid: string;
+    name: string;
 }
 
 export interface IOptionSetMetadata {

--- a/src/utils/Placeholders.ts
+++ b/src/utils/Placeholders.ts
@@ -122,6 +122,12 @@ export class Placeholders {
             case this.wrSearch:
                 qpOptions = { placeHolder: this.ipWRSearch.placeHolderText, title: this.ipWRSearch.prompt, ignoreFocusOut: ignoreFocus };
                 break;
+            case this.pluginSelection:
+                qpOptions = { placeHolder: this.ipPluginSelection.placeHolderText, title: this.ipPluginSelection.prompt, ignoreFocusOut: ignoreFocus };
+                break;
+            case this.pluginLinkSelection:
+                qpOptions = { placeHolder: this.ipPluginLinkSelection.placeHolderText, title: this.ipPluginLinkSelection.prompt, ignoreFocusOut: ignoreFocus };
+                break;
             default:
                 qpOptions = { placeHolder: "", ignoreFocusOut: ignoreFocus };
                 break;
@@ -151,6 +157,8 @@ export class Placeholders {
     public static tsTemplateType: string = "TS-TemplateType";
     public static entitiesSearch: string = "EntitiesSearch";
     public static wrSearch: string = "WRSearch";
+    public static pluginSelection: string = "PluginSelection";
+    public static pluginLinkSelection: string = "PluginLinkSelection";
 
     public static required: string = "[Required]";
     public static optional: string = "[Optional]";
@@ -238,5 +246,13 @@ export class Placeholders {
     private static ipWRSearch: IPlaceholder = {
         placeHolderText: `Search & Select Web Resources`,
         prompt: `Pick multiple web resources`,
+    };
+    private static ipPluginSelection: IPlaceholder = {
+        placeHolderText: `Select the plugin assembly or package`,
+        prompt: `Pick the Dataverse plugin to link with this project`,
+    };
+    private static ipPluginLinkSelection: IPlaceholder = {
+        placeHolderText: `Select your option`,
+        prompt: `This project isn't linked. Link to an existing plugin?`,
     };
 }


### PR DESCRIPTION
## Summary

Adds plugin sync to DVDT — a parallel workflow to web resource sync, but for Dataverse plugin assemblies and packages. Lets developers link a local `.csproj` to an existing PluginAssembly/PluginPackage record and push changes via `pac plugin push` directly from VS Code, without leaving the editor.

## What's new

- Two new right-click commands on `.csproj` files: **Link to Existing Dataverse Plugin** and **Push Plugin to Dataverse**.
- The `dvdt.linker.xml` schema gains a `<Plugins>` section (sibling to `<WebResources>` / `<Settings>`), with one `<Plugin>` element per linked project storing `Id`, `dvName`, `type` (`Assembly`/`Nuget`), `localProjectPath`, and `environment`.

## Design choices worth highlighting

- **Delegates to `pac plugin push`** rather than re-implementing plugin registration.
- **One linker section, `type` attribute discriminator** — matches how `pac plugin push --type Nuget|Assembly` itself models the choice.
- **`environment` is stored per entry**. This lets push run without requiring an active DVDT connection — pac handles its own auth.

## Test plan

- [ ] Connect to a Dataverse env that has unmanaged plugin assemblies and packages — verify both load.
- [ ] Right-click a `.csproj` → Link → quick-pick shows both kinds with type as the description.
- [ ] Link an already-linked project → re-link prompt fires.
- [ ] Cancel the quick-pick → no linker mutation.
- [ ] Push a linked project → pac runs, output channel shows pac's stdout, success toast on exit 0.
- [ ] Push without linking → inline "Link & push" option offered.
- [ ] Push when pac isn't installed → pac-not-found error with "Open install docs" action.
- [ ] Push when pac has no profile for the linker's env → "Authenticate" notification opens a terminal pre-filled with `pac auth create --environment "<url>"`.

## Out of scope for this PR

- Smart Match for plugins (csproj↔record auto-detection).
- A dedicated Plugins tree view in the sidebar.